### PR TITLE
add tests and configuration

### DIFF
--- a/http/action/src/main/java/io/knotx/databridge/http/action/HttpActionOptions.java
+++ b/http/action/src/main/java/io/knotx/databridge/http/action/HttpActionOptions.java
@@ -30,6 +30,7 @@ public class HttpActionOptions {
   private WebClientOptions webClientOptions;
   private EndpointOptions endpointOptions;
   private long requestTimeoutMs;
+  private String responseType = "json";
 
   public HttpActionOptions() {
     init();
@@ -91,6 +92,44 @@ public class HttpActionOptions {
    */
   public HttpActionOptions setRequestTimeoutMs(long requestTimeoutMs) {
     this.requestTimeoutMs = requestTimeoutMs;
+    return this;
+  }
+
+  public String getResponseType() {
+    return responseType;
+  }
+
+  /**
+   * Configures the expected type of response the endpoint will return. Currently supported:
+   *<ul>
+   *   <li>
+   *     {@code json}
+   *     <p>
+   *       The response is appended to `_response` key of action's payload as parsed {@link JsonObject JsonObject}/{@link io.vertx.core.json.JsonArray JsonArray}.
+   *     </p>
+   *   </li>
+   *   <li>
+   *     {@code raw}
+   *     <p>
+   *       The response is appended to `_response` key of action's payload as a {@link JsonObject JsonObject} in the following format:
+   *       <pre>
+   *         {
+   *           "body": "<i>raw response body of the endpoint</i>",
+   *           "contentType": "<i>{@code Content-Type} header value (if any)</i>",
+   *           "encoding": "<i>encoding of the body (if could be determined)</i>
+   *         }
+   *       </pre>
+   *     </p>
+   *   </li>
+   *</ul>
+   *
+   * By default it is set to {@code json}.
+   *
+   * @param responseType - expected response type
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpActionOptions setResponseType(String responseType) {
+    this.responseType = responseType;
     return this;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add tests for new `raw` HttpAction response body functionality.

The `_response` value of the fragment's payload should look something like this:
```json
{
    "body": "raw response body of the endpoint",
    "contentType": "Content-Type header value (if any)",
    "encoding": "encoding of the body (if could be determined)"
}
```

And the configuration:
```hocon
// ...
config {
     endpointOptions {
       path = /service/mock/book.json
       domain = localhost
       port = 3000
       allowedRequestHeaders = ["Content-Type"]
     }
     responseType = raw   // by default: json
   }
// ...
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Response body should not be hard-coded as JSON.

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
